### PR TITLE
Fix memory leak in resize event listener

### DIFF
--- a/game.js
+++ b/game.js
@@ -56,8 +56,9 @@ class MathMistressGame {
         // Set canvas size
         this.resizeCanvas();
         
-        // Setup resize handler
-        window.addEventListener('resize', () => this.resizeCanvas());
+        // Setup resize handler using a stable function reference for proper cleanup
+        this.boundResizeHandler = this.resizeCanvas.bind(this);
+        window.addEventListener('resize', this.boundResizeHandler);
     }
     
     resizeCanvas() {
@@ -715,7 +716,9 @@ class MathMistressGame {
         }
         
         // Clean up event listeners
-        window.removeEventListener('resize', this.resizeCanvas);
+        if (this.boundResizeHandler) {
+            window.removeEventListener('resize', this.boundResizeHandler);
+        }
     }
 }
 


### PR DESCRIPTION
Fix memory leak by ensuring consistent `resize` event listener reference for addition and removal.

Previously, the `resize` event listener was added with an anonymous arrow function (`() => this.resizeCanvas()`), while `removeEventListener` attempted to remove `this.resizeCanvas`, leading to a mismatch and preventing the listener from being detached, thus causing a memory leak.