### PR TITLE
Fix Git merge conflict syntax errors

### DIFF
--- a/MathMistress/tests/syntax.test.js
+++ b/MathMistress/tests/syntax.test.js
@@ -1,0 +1,23 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const PROJECT_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const GAME_FILE = path.join(PROJECT_ROOT, 'game.js');
+
+describe('Project sanity checks', () => {
+  test('game.js has valid JavaScript syntax', () => {
+    // `node --check` exits with a non-zero code on syntax errors.
+    expect(() => execSync(`node --check ${GAME_FILE}`)).not.toThrow();
+  });
+
+  test('game.js has no leftover merge-conflict markers', () => {
+    const content = fs.readFileSync(GAME_FILE, 'utf8');
+    // Typical Git conflict markers
+    const conflictMarkerRegex = /<<<<<<<|=======|>>>>>>>/;
+    expect(conflictMarkerRegex.test(content)).toBe(false);
+
+    // Any accidental branch/commit label artifacts that previously caused issues
+    expect(content.includes('cursor/fix-memory-leak-in-resize-event-listener')).toBe(false);
+  });
+});

--- a/game.js
+++ b/game.js
@@ -56,7 +56,6 @@ class MathMistressGame {
         // Set canvas size
         this.resizeCanvas();
         
-         cursor/fix-memory-leak-in-resize-event-listener-6f7d
         // Setup resize handler - store reference for proper cleanup
         this.resizeHandler = () => this.resizeCanvas();
         window.addEventListener('resize', this.resizeHandler);
@@ -64,7 +63,6 @@ class MathMistressGame {
         // Setup resize handler using a stable function reference for proper cleanup
         this.boundResizeHandler = this.resizeCanvas.bind(this);
         window.addEventListener('resize', this.boundResizeHandler);
-        main
     }
     
     resizeCanvas() {
@@ -721,14 +719,13 @@ class MathMistressGame {
             this.characterSystem.destroy();
         }
         
-        // Clean up event listeners
- cursor/fix-memory-leak-in-resize-event-listener-6f7d
+        // Clean up event listeners for resize
         if (this.resizeHandler) {
             window.removeEventListener('resize', this.resizeHandler);
+        }
 
         if (this.boundResizeHandler) {
             window.removeEventListener('resize', this.boundResizeHandler);
- main
         }
     }
 }


### PR DESCRIPTION
Fix syntax errors caused by leftover Git merge conflict markers and add a test to prevent recurrence.

This PR resolves syntax errors in `game.js` where Git merge conflict markers (`main`, `cursor/fix-...`) were left behind, specifically replacing a missing closing brace in the `destroy` method. The fix restores correct syntax and ensures proper cleanup of resize event listeners. A new Jest test (`MathMistress/tests/syntax.test.js`) has been added to verify `game.js` syntax and check for any future leftover merge conflict markers.