### PR TITLE
Fix duplicate window resize event listeners

### DIFF
--- a/game.js
+++ b/game.js
@@ -59,10 +59,6 @@ class MathMistressGame {
         // Setup resize handler - store reference for proper cleanup
         this.resizeHandler = () => this.resizeCanvas();
         window.addEventListener('resize', this.resizeHandler);
-
-        // Setup resize handler using a stable function reference for proper cleanup
-        this.boundResizeHandler = this.resizeCanvas.bind(this);
-        window.addEventListener('resize', this.boundResizeHandler);
     }
     
     resizeCanvas() {
@@ -722,10 +718,6 @@ class MathMistressGame {
         // Clean up event listeners for resize
         if (this.resizeHandler) {
             window.removeEventListener('resize', this.resizeHandler);
-        }
-
-        if (this.boundResizeHandler) {
-            window.removeEventListener('resize', this.boundResizeHandler);
         }
     }
 }


### PR DESCRIPTION
Remove duplicate `window.resize` event listener to prevent `resizeCanvas()` from being called twice and reduce performance overhead.

This duplicate registration was likely introduced during a merge conflict, causing `resizeCanvas()` to be invoked twice per resize event.