### PR TITLE
Fix duplicate window resize event listeners

### DIFF
--- a/game.js
+++ b/game.js
@@ -56,10 +56,6 @@ class MathMistressGame {
         // Set canvas size
         this.resizeCanvas();
         
-        // Setup resize handler - store reference for proper cleanup
-        this.resizeHandler = () => this.resizeCanvas();
-        window.addEventListener('resize', this.resizeHandler);
-
         // Setup resize handler using a stable function reference for proper cleanup
         this.boundResizeHandler = this.resizeCanvas.bind(this);
         window.addEventListener('resize', this.boundResizeHandler);
@@ -720,10 +716,6 @@ class MathMistressGame {
         }
         
         // Clean up event listeners for resize
-        if (this.resizeHandler) {
-            window.removeEventListener('resize', this.resizeHandler);
-        }
-
         if (this.boundResizeHandler) {
             window.removeEventListener('resize', this.boundResizeHandler);
         }


### PR DESCRIPTION
Remove duplicate `window.resize` event listener to prevent `resizeCanvas()` from being called twice.