### PR TITLE
Fix duplicate resize event listeners

### DIFF
--- a/game.js
+++ b/game.js
@@ -56,15 +56,9 @@ class MathMistressGame {
         // Set canvas size
         this.resizeCanvas();
         
-cursor/fix-duplicate-window-resize-event-listeners-d98a
         // Setup resize handler using a stable function reference for proper cleanup
         this.boundResizeHandler = this.resizeCanvas.bind(this);
         window.addEventListener('resize', this.boundResizeHandler);
-
-        // Setup resize handler - store reference for proper cleanup
-        this.resizeHandler = () => this.resizeCanvas();
-        window.addEventListener('resize', this.resizeHandler);
-cursor/fix-git-merge-conflict-syntax-errors-c9ad
     }
     
     resizeCanvas() {


### PR DESCRIPTION
Remove duplicate window resize event listener and merge conflict markers to prevent `resizeCanvas()` from being called twice and clean up code.