### PR TITLE
Remove invalid development tool markers

### DIFF
--- a/game.js
+++ b/game.js
@@ -719,11 +719,7 @@ class MathMistressGame {
             this.characterSystem.destroy();
         }
         
- cursor/fix-git-merge-conflict-syntax-errors-a6df
-        // Clean up event listeners
-
         // Clean up event listeners for resize
- main
         if (this.resizeHandler) {
             window.removeEventListener('resize', this.resizeHandler);
         }

--- a/game.js
+++ b/game.js
@@ -56,10 +56,6 @@ class MathMistressGame {
         // Set canvas size
         this.resizeCanvas();
         
-        // Setup resize handler - store reference for proper cleanup
-        this.resizeHandler = () => this.resizeCanvas();
-        window.addEventListener('resize', this.resizeHandler);
-
         // Setup resize handler using a stable function reference for proper cleanup
         this.boundResizeHandler = this.resizeCanvas.bind(this);
         window.addEventListener('resize', this.boundResizeHandler);
@@ -719,11 +715,7 @@ class MathMistressGame {
             this.characterSystem.destroy();
         }
         
-        // Clean up event listeners for resize
-        if (this.resizeHandler) {
-            window.removeEventListener('resize', this.resizeHandler);
-        }
-
+        // Clean up event listener for resize
         if (this.boundResizeHandler) {
             window.removeEventListener('resize', this.boundResizeHandler);
         }


### PR DESCRIPTION
Remove accidental merge conflict marker and redundant resize event listener registration.

The task aimed to remove specific development markers (`cursor/fix-duplicate-resize-event-listeners-6887`, `cursor/fix-duplicate-window-resize-event-listeners-d98a`) causing syntax errors and duplicate event listeners. These markers were not found in the current codebase. Instead, a different accidental merge conflict marker (`cursor/fix-git-merge-conflict-syntax-errors-a6df`) and a duplicate `window.addEventListener('resize')` setup were removed, resolving the reported syntax errors and ensuring only one resize handler is active.