### PR TITLE
Fix merge conflict and duplicate listeners

### DIFF
--- a/game.js
+++ b/game.js
@@ -55,16 +55,10 @@ class MathMistressGame {
         
         // Set canvas size
         this.resizeCanvas();
-        
-cursor/fix-duplicate-window-resize-event-listeners-d98a
+
         // Setup resize handler using a stable function reference for proper cleanup
         this.boundResizeHandler = this.resizeCanvas.bind(this);
         window.addEventListener('resize', this.boundResizeHandler);
-
-        // Setup resize handler - store reference for proper cleanup
-        this.resizeHandler = () => this.resizeCanvas();
-        window.addEventListener('resize', this.resizeHandler);
-cursor/fix-git-merge-conflict-syntax-errors-c9ad
     }
     
     resizeCanvas() {
@@ -722,12 +716,8 @@ cursor/fix-git-merge-conflict-syntax-errors-c9ad
         }
         
         // Clean up event listeners for resize
-cursor/fix-duplicate-window-resize-event-listeners-d98a
         if (this.boundResizeHandler) {
             window.removeEventListener('resize', this.boundResizeHandler);
-
-        if (this.resizeHandler) {
-            window.removeEventListener('resize', this.resizeHandler); cursor/fix-git-merge-conflict-syntax-errors-c9ad
         }
     }
 }


### PR DESCRIPTION
Remove Git merge conflict markers and fix duplicate `window.resize` event listeners in `game.js`.

Leftover merge markers caused syntax errors. Additionally, `setupCanvas` was registering two `window.resize` listeners, leading to `resizeCanvas` being called twice per resize event.